### PR TITLE
chore: add nix flake with dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ coverage
 
 # Docker
 .docker/
+
+# Direnv
+.direnv/

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ pnpm dev
   pnpm db:studio
   ```
 
+#### ❄️ Nix Flake
+
+This project includes a Nix flake for a reproducible development environment.
+
+To enter the Nix shell:
+```bash
+nix develop
+```
+
+This will drop you in a Bash shell with Node, Pnpm, Rust & Tauri.
+
+You can also use direnv to automatically enter the Nix shell when you `cd` into the project. (More info: https://direnv.net/)
+
 ## 🏗️ Building
 
 ### Frontend (Tauri App)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762361079,
+        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1762483116,
+        "narHash": "sha256-Z8EVsTH10BjCdFyPxbUu5jBV+HGL39rh9+beQcnNRm0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9de55b59b6aaadbd9dbf223765a835239b767ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+
+        toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        packages = with pkgs; [
+          nodejs_24
+          cargo
+          cargo-tauri
+          toolchain
+          rust-analyzer-unwrapped
+          nodePackages.pnpm
+        ];
+
+
+        nativeBuildPackages = with pkgs; [
+          pkg-config
+          dbus
+          openssl
+          glib
+          gtk3
+          librsvg
+        ];
+
+        libraries = with pkgs; [
+          gtk3
+          cairo
+          gdk-pixbuf
+          glib
+          dbus
+          openssl
+          librsvg
+        ];
+
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = packages;
+          nativeBuildInputs = nativeBuildPackages;
+
+          shellHook = with pkgs; ''
+            export LD_LIBRARY_PATH="${
+              lib.makeLibraryPath libraries
+            }:$LD_LIBRARY_PATH"
+            export OPENSSL_INCLUDE_DIR="${openssl.dev}/include/openssl"
+            export OPENSSL_LIB_DIR="${openssl.out}/lib"
+            export OPENSSL_ROOT_DIR="${openssl.out}"
+            export RUST_SRC_PATH="${toolchain}/lib/rustlib/src/rust/library"
+          '';
+        };
+      });
+}
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "rust-src"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]


### PR DESCRIPTION
I hate installing rust. This makes it less of a pain :D 

(This also adds node24, though if `.nvmrc` gets updated we would need to update the flake separately)

Note: I haven't tested this on linux yet, only darwin.